### PR TITLE
Add Topic and Payload to Info output

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,11 @@ module.exports = function(RED) {
                                 : events.off.moment.toDate().toUTCString(),
                             state: isSuspended()
                                 ? 'suspended'
-                                : events.off.moment.isAfter(events.on.moment) ? 'off' : 'on'
+                                : events.off.moment.isAfter(events.on.moment) ? 'off' : 'on',
+                            ontopic: events.on.topic,
+                            onpayload: events.on.payload,
+                            offtopic: events.off.topic,
+                            offpayload: events.off.payload
                         }
                     });
                 } else {


### PR DESCRIPTION
Add the values of the on and off topics and payloads to the Info command output. The reasoning behind this is for the case where the multiple schedex nodes are called based on a list of items. For example a group of lights in Home Assistant. By outputting the unique topic and payload input to the node on an info command the scheduling information can be tied to the item being scheduled.